### PR TITLE
feat: 添加 Turnstile 人机验证和认证接口防滥用措施

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,10 @@ VITE_BLOG_DESCRIPTION=一个基于 Cloudflare Workers 的博客
 VITE_BLOG_GITHUB=https://github.com/your-username
 VITE_BLOG_EMAIL=your-email@example.com
 
+# --- Turnstile 人机验证（可选） ---
+# 测试用 key（始终通过）: VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+# 测试用 key（始终失败）: VITE_TURNSTILE_SITE_KEY=2x00000000000000000000AB
+# VITE_TURNSTILE_SITE_KEY=your-turnstile-site-key
+
 # --- Umami 统计（可选） ---
 VITE_UMAMI_WEBSITE_ID=your-umami-website-id

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,7 @@ jobs:
           echo "UMAMI_USERNAME=${{ secrets.UMAMI_USERNAME }}" >> $GITHUB_ENV
           echo "UMAMI_PASSWORD=${{ secrets.UMAMI_PASSWORD }}" >> $GITHUB_ENV
           echo "VITE_UMAMI_WEBSITE_ID=${{ vars.VITE_UMAMI_WEBSITE_ID }}" >> $GITHUB_ENV
+          echo "VITE_TURNSTILE_SITE_KEY=${{ vars.VITE_TURNSTILE_SITE_KEY }}" >> $GITHUB_ENV
           echo "VITE_BLOG_TITLE=${{ vars.VITE_BLOG_TITLE }}" >> $GITHUB_ENV
           echo "VITE_BLOG_NAME=${{ vars.VITE_BLOG_NAME }}" >> $GITHUB_ENV
           echo "VITE_BLOG_AUTHOR=${{ vars.VITE_BLOG_AUTHOR }}" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 所有重要变更都会记录在此文件中。
 
+## 2026-02-08
+
+### 🛡️ Security
+
+- **Anti-Abuse 多层防护** — 防止认证接口被恶意滥用
+  - Cloudflare Turnstile 人机验证（客户端 invisible 模式，零用户摩擦）
+  - 按邮箱限流：密码重置和邮箱验证每邮箱 3 次/小时，超限静默跳过
+  - POST `/api/auth/*` 速率限制从 10 次/分钟收紧至 5 次/分钟
+  - 新增可选环境变量：`VITE_TURNSTILE_SITE_KEY`（构建时）
+  - 未配置 Turnstile 时自动跳过验证，不影响现有功能
+
 ## 2026-02-07
 
 ### ✨ New Feature

--- a/README.md
+++ b/README.md
@@ -212,15 +212,16 @@ VITE_UMAMI_WEBSITE_ID=your-website-id
 
 #### GitHub Variables（可选，客户端配置）
 
-| 变量名                  | 类型   | 说明                       |
-| :---------------------- | :----- | :------------------------- |
-| `VITE_UMAMI_WEBSITE_ID` | 构建时 | Umami Website ID           |
-| `VITE_BLOG_TITLE`       | 构建时 | 博客标题                   |
-| `VITE_BLOG_NAME`        | 构建时 | 博客短名称，显示在导航栏上 |
-| `VITE_BLOG_AUTHOR`      | 构建时 | 作者名称                   |
-| `VITE_BLOG_DESCRIPTION` | 构建时 | 博客描述，显示在主页上     |
-| `VITE_BLOG_GITHUB`      | 构建时 | GitHub 主页链接            |
-| `VITE_BLOG_EMAIL`       | 构建时 | 联系邮箱                   |
+| 变量名                    | 类型   | 说明                          |
+| :------------------------ | :----- | :---------------------------- |
+| `VITE_TURNSTILE_SITE_KEY` | 构建时 | Cloudflare Turnstile 人机验证 |
+| `VITE_UMAMI_WEBSITE_ID`   | 构建时 | Umami Website ID              |
+| `VITE_BLOG_TITLE`         | 构建时 | 博客标题                      |
+| `VITE_BLOG_NAME`          | 构建时 | 博客短名称，显示在导航栏上    |
+| `VITE_BLOG_AUTHOR`        | 构建时 | 作者名称                      |
+| `VITE_BLOG_DESCRIPTION`   | 构建时 | 博客描述，显示在主页上        |
+| `VITE_BLOG_GITHUB`        | 构建时 | GitHub 主页链接               |
+| `VITE_BLOG_EMAIL`         | 构建时 | 联系邮箱                      |
 
 > **构建时变量**：在 Vite 构建时注入到客户端代码，方式二用户在 Build Variables 中配置
 

--- a/src/components/common/turnstile.tsx
+++ b/src/components/common/turnstile.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { clientEnv } from "@/lib/env/client.env";
+
+const TURNSTILE_SCRIPT_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        options: Record<string, unknown>,
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+interface TurnstileProps {
+  onVerify: (token: string) => void;
+  onError?: () => void;
+  onExpire?: () => void;
+  action?: string;
+}
+
+let scriptLoadPromise: Promise<void> | null = null;
+
+function loadScript(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+  if (scriptLoadPromise) return scriptLoadPromise;
+
+  scriptLoadPromise = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = TURNSTILE_SCRIPT_URL;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      scriptLoadPromise = null;
+      reject(new Error("Failed to load Turnstile script"));
+    };
+    document.head.appendChild(script);
+  });
+
+  return scriptLoadPromise;
+}
+
+export function Turnstile({
+  onVerify,
+  onError,
+  onExpire,
+  action,
+}: TurnstileProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  const siteKey = clientEnv().VITE_TURNSTILE_SITE_KEY;
+
+  useEffect(() => {
+    if (!siteKey || !containerRef.current) return;
+
+    let mounted = true;
+
+    loadScript()
+      .then(() => {
+        if (!mounted || !containerRef.current || !window.turnstile) return;
+
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: siteKey,
+          callback: onVerify,
+          "error-callback": onError,
+          "expired-callback": onExpire,
+          action,
+          appearance: "interaction-only",
+        });
+      })
+      .catch(() => {
+        // Turnstile script failed to load — skip silently
+      });
+
+    return () => {
+      mounted = false;
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [siteKey, onVerify, onError, onExpire, action]);
+
+  if (!siteKey) return null;
+
+  return <div ref={containerRef} />;
+}
+
+/**
+ * Hook for using Turnstile in forms (client-side only).
+ * Returns { isPending, turnstileProps } — spread turnstileProps onto <Turnstile />.
+ * Use `isPending` to disable submit buttons until verification completes.
+ */
+export function useTurnstile(action?: string) {
+  const [verified, setVerified] = useState(false);
+  const siteKey = clientEnv().VITE_TURNSTILE_SITE_KEY;
+
+  const onVerify = useCallback(() => setVerified(true), []);
+  const onExpire = useCallback(() => setVerified(false), []);
+
+  return {
+    /** Turnstile is configured but challenge not yet completed */
+    isPending: !!siteKey && !verified,
+    turnstileProps: { onVerify, onExpire, action } satisfies TurnstileProps,
+  };
+}

--- a/src/features/auth/components/forgot-password-form.tsx
+++ b/src/features/auth/components/forgot-password-form.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Input } from "@/components/ui/input";
+import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 import { authClient } from "@/lib/auth/auth.client";
 
 const forgotPasswordSchema = z.object({
@@ -18,6 +19,8 @@ export function ForgotPasswordForm() {
   const navigate = useNavigate();
   const [isSent, setIsSent] = useState(false);
   const [sentEmail, setSentEmail] = useState("");
+
+  const { turnstileProps } = useTurnstile("forgot-password");
 
   const {
     register,
@@ -72,6 +75,7 @@ export function ForgotPasswordForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      <Turnstile {...turnstileProps} />
       <p className="text-sm text-muted-foreground/60 font-light leading-relaxed">
         请输入您的注册邮箱，我们将向您发送重置密码的链接。
       </p>

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Input } from "@/components/ui/input";
+import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 import { usePreviousLocation } from "@/hooks/use-previous-location";
 import { authClient } from "@/lib/auth/auth.client";
 import { AUTH_KEYS } from "@/features/auth/queries";
@@ -28,6 +29,7 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
   const navigate = useNavigate();
   const previousLocation = usePreviousLocation();
   const queryClient = useQueryClient();
+  const { turnstileProps } = useTurnstile("login");
 
   const {
     register,
@@ -88,6 +90,7 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      <Turnstile {...turnstileProps} />
       {errors.root && (
         <div className="border-l-2 border-destructive p-4 space-y-2 animate-in fade-in duration-300">
           <p className="text-[10px] font-mono text-destructive uppercase tracking-widest">

--- a/src/features/auth/components/register-form.tsx
+++ b/src/features/auth/components/register-form.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Input } from "@/components/ui/input";
+import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 import { usePreviousLocation } from "@/hooks/use-previous-location";
 import { authClient } from "@/lib/auth/auth.client";
 import { AUTH_KEYS } from "@/features/auth/queries";
@@ -31,6 +32,7 @@ export function RegisterForm() {
   const [isSuccess, setIsSuccess] = React.useState(false);
   const previousLocation = usePreviousLocation();
   const queryClient = useQueryClient();
+  const { turnstileProps } = useTurnstile("register");
 
   const {
     register,
@@ -96,6 +98,7 @@ export function RegisterForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      <Turnstile {...turnstileProps} />
       <div className="space-y-6">
         {/* Name */}
         <div className="space-y-2 group">

--- a/src/features/comments/components/view/comment-editor.tsx
+++ b/src/features/comments/components/view/comment-editor.tsx
@@ -15,6 +15,7 @@ interface CommentEditorProps {
   autoFocus?: boolean;
   onCancel?: () => void;
   submitLabel?: string;
+  disabled?: boolean;
 }
 
 export const CommentEditor = ({
@@ -23,6 +24,7 @@ export const CommentEditor = ({
   autoFocus,
   onCancel,
   submitLabel = "发表评论",
+  disabled,
 }: CommentEditorProps) => {
   const [modalType, setModalType] = useState<ModalType>(null);
   const [modalInitialUrl, setModalInitialUrl] = useState("");
@@ -96,7 +98,7 @@ export const CommentEditor = ({
           )}
           <Button
             size="sm"
-            disabled={isEmpty || isSubmitting}
+            disabled={isEmpty || isSubmitting || disabled}
             onClick={handleSubmit}
             variant="ghost"
             className="h-8 px-4 text-[10px] font-bold uppercase tracking-widest hover:bg-transparent hover:text-foreground p-0 flex items-center gap-2 group/btn"

--- a/src/features/comments/components/view/comment-list.tsx
+++ b/src/features/comments/components/view/comment-list.tsx
@@ -23,6 +23,7 @@ interface CommentListProps {
   isSubmittingReply?: boolean;
   initialExpandedRootId?: number;
   highlightCommentId?: number;
+  disableSubmit?: boolean;
 }
 
 export const CommentList = ({
@@ -36,6 +37,7 @@ export const CommentList = ({
   isSubmittingReply,
   initialExpandedRootId,
   highlightCommentId,
+  disableSubmit,
 }: CommentListProps) => {
   const { data: session } = authClient.useSession();
   const [expandedRoots, setExpandedRoots] = useState<Set<number>>(new Set());
@@ -85,6 +87,7 @@ export const CommentList = ({
           isSubmittingReply={isSubmittingReply}
           session={session}
           highlightCommentId={highlightCommentId}
+          disableSubmit={disableSubmit}
         />
       ))}
     </div>
@@ -104,6 +107,7 @@ interface RootCommentWithRepliesProps {
   isSubmittingReply?: boolean;
   session: AuthContext["session"] | null;
   highlightCommentId?: number;
+  disableSubmit?: boolean;
 }
 
 function RootCommentWithReplies({
@@ -119,6 +123,7 @@ function RootCommentWithReplies({
   isSubmittingReply,
   session,
   highlightCommentId,
+  disableSubmit,
 }: RootCommentWithRepliesProps) {
   const {
     data: repliesData,
@@ -158,11 +163,12 @@ function RootCommentWithReplies({
               isSubmitting={isSubmittingReply!}
               onCancel={onCancelReply!}
               className="mt-0"
+              disabled={disableSubmit}
             />
           ) : (
             <div className="flex items-center gap-4 py-4 bg-muted/5 rounded-sm px-4">
               <span className="text-[10px] text-muted-foreground uppercase tracking-wider flex-1">
-                Login to reply @{replyTarget.userName}
+                登录以回复 @{replyTarget.userName}
               </span>
               <Link to="/login">
                 <Button
@@ -170,14 +176,14 @@ function RootCommentWithReplies({
                   size="sm"
                   className="h-7 px-3 text-[9px] uppercase tracking-widest font-bold border-border/40 hover:bg-foreground hover:text-background transition-all"
                 >
-                  Login
+                  登录
                 </Button>
               </Link>
               <button
                 onClick={onCancelReply}
                 className="text-[9px] uppercase tracking-widest font-bold text-muted-foreground/50 hover:text-foreground transition-colors"
               >
-                Cancel
+                取消
               </button>
             </div>
           )}
@@ -238,7 +244,7 @@ function RootCommentWithReplies({
                         ) : (
                           <div className="flex items-center gap-4 py-4 bg-muted/5 rounded-sm px-4">
                             <span className="text-[10px] text-muted-foreground uppercase tracking-wider flex-1">
-                              Login to reply @{replyTarget.userName}
+                              登录以回复 @{replyTarget.userName}
                             </span>
                             <Link to="/login">
                               <Button
@@ -246,14 +252,14 @@ function RootCommentWithReplies({
                                 size="sm"
                                 className="h-7 px-3 text-[9px] uppercase tracking-widest font-bold border-border/40 hover:bg-foreground hover:text-background transition-all"
                               >
-                                Login
+                                登录
                               </Button>
                             </Link>
                             <button
                               onClick={onCancelReply}
                               className="text-[9px] uppercase tracking-widest font-bold text-muted-foreground/50 hover:text-foreground transition-colors"
                             >
-                              Cancel
+                              取消
                             </button>
                           </div>
                         )}

--- a/src/features/comments/components/view/comment-reply-form.tsx
+++ b/src/features/comments/components/view/comment-reply-form.tsx
@@ -8,6 +8,7 @@ interface CommentReplyFormProps {
   isSubmitting: boolean;
   onCancel: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 export const CommentReplyForm = ({
@@ -16,6 +17,7 @@ export const CommentReplyForm = ({
   isSubmitting,
   onCancel,
   className,
+  disabled,
 }: CommentReplyFormProps) => {
   return (
     <div
@@ -38,6 +40,7 @@ export const CommentReplyForm = ({
         autoFocus
         onCancel={onCancel}
         submitLabel="发表回复"
+        disabled={disabled}
       />
     </div>
   );

--- a/src/features/comments/components/view/comment-section.tsx
+++ b/src/features/comments/components/view/comment-section.tsx
@@ -11,6 +11,7 @@ import type { JSONContent } from "@tiptap/react";
 import { authClient } from "@/lib/auth/auth.client";
 import { Button } from "@/components/ui/button";
 import ConfirmationModal from "@/components/ui/confirmation-modal";
+import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 
 const routeApi = getRouteApi("/_public/post/$slug");
 
@@ -39,6 +40,8 @@ export const CommentSection = ({ postId }: CommentSectionProps) => {
   } | null>(null);
 
   const [commentToDelete, setCommentToDelete] = useState<number | null>(null);
+  const { isPending: turnstilePending, turnstileProps } =
+    useTurnstile("comment");
 
   const handleCreateComment = async (content: JSONContent) => {
     await createComment({
@@ -119,12 +122,15 @@ export const CommentSection = ({ postId }: CommentSectionProps) => {
         </div>
       </header>
 
+      <Turnstile {...turnstileProps} />
+
       {/* Main Editor */}
       {session ? (
         <div className="space-y-6">
           <CommentEditor
             onSubmit={handleCreateComment}
             isSubmitting={isCreating && !replyTarget}
+            disabled={turnstilePending}
           />
         </div>
       ) : (
@@ -158,6 +164,7 @@ export const CommentSection = ({ postId }: CommentSectionProps) => {
         isSubmittingReply={isCreating}
         initialExpandedRootId={rootId}
         highlightCommentId={highlightCommentId}
+        disableSubmit={turnstilePending}
       />
 
       {/* Load More Root Comments */}

--- a/src/features/friend-links/components/user/friend-link-submit-form.tsx
+++ b/src/features/friend-links/components/user/friend-link-submit-form.tsx
@@ -6,6 +6,7 @@ import { useFriendLinks } from "../../hooks/use-friend-links";
 import type { SubmitFriendLinkInput } from "../../friend-links.schema";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 
 interface FriendLinkSubmitFormProps {
   defaultEmail?: string;
@@ -15,6 +16,8 @@ export function FriendLinkSubmitForm({
   defaultEmail,
 }: FriendLinkSubmitFormProps) {
   const { submit, isSubmitting } = useFriendLinks();
+  const { isPending: turnstilePending, turnstileProps } =
+    useTurnstile("friend-link");
 
   const {
     register,
@@ -40,6 +43,7 @@ export function FriendLinkSubmitForm({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      <Turnstile {...turnstileProps} />
       <div className="space-y-6">
         <div className="space-y-2 group">
           <label className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider group-focus-within:text-foreground transition-colors">
@@ -125,7 +129,7 @@ export function FriendLinkSubmitForm({
       <div className="flex justify-start">
         <Button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || turnstilePending}
           variant="ghost"
           className="font-mono text-xs text-muted-foreground hover:text-foreground hover:bg-transparent p-0 h-auto transition-colors"
         >

--- a/src/lib/env/client.env.ts
+++ b/src/lib/env/client.env.ts
@@ -2,6 +2,7 @@ import z from "zod";
 
 const clientEnvSchema = z.object({
   VITE_UMAMI_WEBSITE_ID: z.string().optional(),
+  VITE_TURNSTILE_SITE_KEY: z.string().optional(),
   // 博客配置
   VITE_BLOG_TITLE: z.string().optional(),
   VITE_BLOG_NAME: z.string().optional(),

--- a/src/lib/hono/hono.test.ts
+++ b/src/lib/hono/hono.test.ts
@@ -21,7 +21,7 @@ describe("Hono Integration Test", () => {
 
     const url = "/api/auth/sign-in/email";
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 5; i++) {
       const res = await testRequest(app, url, reqInit);
       expect(res.status).not.toBe(429);
     }

--- a/src/lib/hono/routes.ts
+++ b/src/lib/hono/routes.ts
@@ -93,7 +93,7 @@ app.post(
   "/api/auth/*",
   baseMiddleware,
   rateLimitMiddleware({
-    capacity: 10,
+    capacity: 5,
     interval: "1m",
     identifier: createRateLimiterIdentifier,
   }),


### PR DESCRIPTION
- 集成 Cloudflare Turnstile 客户端验证（managed + interaction-only 模式）
- 按邮箱限流：密码重置和邮箱验证每邮箱 3 次/小时，超限静默跳过
- POST /api/auth/* 速率限制从 10 次/分钟收紧至 5 次/分钟