### PR TITLE
fix(auth): scope Turnstile verification to public-facing endpoints only

### DIFF
--- a/src/features/auth/components/forgot-password-form.tsx
+++ b/src/features/auth/components/forgot-password-form.tsx
@@ -10,7 +10,7 @@ import { Turnstile, useTurnstile } from "@/components/common/turnstile";
 import { authClient } from "@/lib/auth/auth.client";
 
 const forgotPasswordSchema = z.object({
-  email: z.string().email("无效的邮箱格式"),
+  email: z.email("无效的邮箱格式"),
 });
 
 type ForgotPasswordSchema = z.infer<typeof forgotPasswordSchema>;

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -13,7 +13,7 @@ import { authClient } from "@/lib/auth/auth.client";
 import { AUTH_KEYS } from "@/features/auth/queries";
 
 const loginSchema = z.object({
-  email: z.string().email("无效的邮箱格式"),
+  email: z.email("无效的邮箱格式"),
   password: z.string().min(1, "请输入密码"),
 });
 
@@ -99,6 +99,9 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
       authClient.sendVerificationEmail({
         email: emailValue,
         callbackURL: `${window.location.origin}/verify-email`,
+        fetchOptions: {
+          headers: { "X-Turnstile-Token": turnstileToken || "" },
+        },
       }),
       {
         loading: "正在发送验证邮件...",

--- a/src/features/auth/components/register-form.tsx
+++ b/src/features/auth/components/register-form.tsx
@@ -15,7 +15,7 @@ import { AUTH_KEYS } from "@/features/auth/queries";
 const registerSchema = z
   .object({
     name: z.string().min(2, "昵称至少 2 位"),
-    email: z.string().email("无效的邮箱格式"),
+    email: z.email("无效的邮箱格式"),
     password: z.string().min(8, "密码至少 8 位"),
     confirmPassword: z.string(),
   })

--- a/src/lib/hono/hono.test.ts
+++ b/src/lib/hono/hono.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testRequest } from "tests/test-utils";
+
 import { app } from "@/lib/hono";
+
+vi.mock("@/lib/turnstile", () => ({
+  verifyTurnstileToken: vi.fn(() => Promise.resolve({ success: true })),
+}));
 
 describe("Hono Integration Test", () => {
   beforeEach(() => {
@@ -16,6 +21,7 @@ describe("Hono Integration Test", () => {
       method: "POST",
       headers: {
         "cf-connecting-ip": "bad-ip",
+        "X-Turnstile-Token": "test-token",
       },
     };
 


### PR DESCRIPTION
- Split auth POST routes into protected (with Turnstile + stricter rate limits) and unprotected (sign-out, change-password, etc.)
- Add Turnstile token header to social login and send-verification-email
- Add Turnstile pending state to social login button
- Update Zod email validation to v4 syntax (z.email())
- Mock Turnstile in hono integration tests