### PR TITLE
feat: 添加 Effect-TS 基础设施和服务示例，测试Code Rabbit挑刺能力

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.44.7",
         "drizzle-zod": "^0.8.3",
+        "effect": "^3.19.18",
         "feed": "^5.2.0",
         "hono": "^4.10.8",
         "lucide-react": "^0.544.0",
@@ -1102,6 +1103,8 @@
 
     "drizzle-zod": ["drizzle-zod@0.8.3", "", { "peerDependencies": { "drizzle-orm": "0.44.7", "zod": "4.1.13" } }, "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww=="],
 
+    "effect": ["effect@3.19.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-KlbNuYzzwpOpnpshIhjCaqweQkthAT1oVG61Z2wIHqo6Sb6n/+pgzFXyTvsLyxcx5Cg3aWaQXa0XQHMuzdVW4A=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.240", "", {}, "sha512-OBwbZjWgrCOH+g6uJsA2/7Twpas2OlepS9uvByJjR2datRDuKGYeD+nP8lBBks2qnB7bGJNHDUx7c/YLaT3QMQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1171,6 +1174,8 @@
     "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
@@ -1581,6 +1586,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.44.7",
     "drizzle-zod": "^0.8.3",
+    "effect": "^3.19.18",
     "feed": "^5.2.0",
     "hono": "^4.10.8",
     "lucide-react": "^0.544.0",

--- a/src/features/cache/cache.service.effect.ts
+++ b/src/features/cache/cache.service.effect.ts
@@ -1,0 +1,201 @@
+/**
+ * Effect 版本的 CacheService 示例
+ *
+ * 这个文件展示了如何使用 Effect 的 Context/Tag 模式来实现缓存服务。
+ * 与 async/await 版本 (cache.service.ts) 并存，作为 Effect 用法的示例。
+ *
+ * 主要区别:
+ * - 使用 Effect.gen 替代 async/await
+ * - 使用 Context.Tag 定义服务接口
+ * - 使用 Layer 管理依赖注入
+ * - 使用 Schema 进行类型安全的编解码
+ */
+
+import { Context, Data, Effect, Layer, Option, Schema } from "effect";
+import { serializeKey } from "./cache.utils";
+import type { CacheKey, CacheNamespace } from "./types";
+import { CloudflareExecutionContextService } from "@/services/cloudflare-env";
+import { KVService } from "@/services/kv";
+
+// Effect 错误类型
+export class CacheError extends Data.TaggedError("CacheError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+// Effect 版本的 CacheService
+const make = Effect.gen(function* () {
+  const { kv } = yield* KVService;
+  const { executionCtx } = yield* CloudflareExecutionContextService;
+
+  /**
+   * 带缓存的 Effect 数据获取
+   * 如果缓存命中，直接返回；否则执行 effect 并缓存结果
+   */
+  const cachedData = <TType, TEncoded, TSchemaReq, TErr, TReq>(
+    key: CacheKey,
+    schema: Schema.Schema<TType, TEncoded, TSchemaReq>,
+    effect: Effect.Effect<TType, TErr, TReq>,
+    options: { ttl?: number } = {},
+  ) =>
+    Effect.gen(function* () {
+      const { ttl = 3600 } = options;
+      const serializedKey = serializeKey(key);
+
+      // 尝试从缓存读取
+      const cached = yield* Effect.tryPromise({
+        try: () => kv.get(serializedKey, "json"),
+        catch: (error) =>
+          new CacheError({
+            message: `获取缓存数据失败: ${String(key)}`,
+            cause: error,
+          }),
+      }).pipe(Effect.option);
+
+      // 如果缓存命中且解码成功，返回缓存数据
+      if (Option.isSome(cached)) {
+        const decoded = yield* Schema.decodeUnknown(schema)(cached.value).pipe(
+          Effect.option,
+        );
+        if (Option.isSome(decoded)) {
+          return decoded.value;
+        }
+      }
+
+      // 缓存未命中，执行 effect 获取数据
+      const data = yield* effect;
+
+      // 后台写入缓存
+      if (data !== null && data !== undefined) {
+        const backgroundTask = Effect.ignoreLogged(
+          Effect.gen(function* () {
+            const encodedData = yield* Schema.encode(schema)(data);
+            yield* Effect.try({
+              try: () =>
+                executionCtx.waitUntil(
+                  kv.put(serializedKey, JSON.stringify(encodedData), {
+                    expirationTtl: ttl,
+                  }),
+                ),
+              catch: (error) =>
+                new CacheError({
+                  message: `保存缓存数据失败: ${String(key)}`,
+                  cause: error,
+                }),
+            });
+          }),
+        );
+        yield* backgroundTask;
+      }
+
+      return data;
+    });
+
+  /**
+   * 删除缓存数据
+   */
+  const deleteCachedData = (...keys: Array<CacheKey>) =>
+    Effect.gen(function* () {
+      const serializedKeys = keys.map(serializeKey);
+      yield* Effect.tryPromise({
+        try: () =>
+          Promise.all(
+            serializedKeys.map((key) => executionCtx.waitUntil(kv.delete(key))),
+          ),
+        catch: (error) =>
+          new CacheError({
+            message: `删除缓存数据失败: ${keys.join(",")}`,
+            cause: error,
+          }),
+      });
+    }).pipe(Effect.catchAll((error) => Effect.logError(error.message)));
+
+  /**
+   * 获取缓存版本号
+   */
+  const getCacheVersion = (namespace: CacheNamespace) =>
+    Effect.gen(function* () {
+      const key = `ver:${namespace}`;
+      const version = yield* Effect.tryPromise({
+        try: () => kv.get(key),
+        catch: (error) =>
+          new CacheError({
+            message: `获取缓存版本号失败: ${namespace}`,
+            cause: error,
+          }),
+      }).pipe(
+        Effect.tapErrorTag("CacheError", (error) =>
+          Effect.logError(error.message),
+        ),
+        Effect.orElseSucceed(() => null),
+      );
+      if (version && !Number.isNaN(Number.parseInt(version))) {
+        return `v${version}`;
+      }
+      return "v1";
+    });
+
+  /**
+   * 升级缓存版本号
+   */
+  const bumpCacheVersion = (namespace: CacheNamespace) =>
+    Effect.gen(function* () {
+      const key = `ver:${namespace}`;
+      const current = yield* Effect.tryPromise({
+        try: () => kv.get(key),
+        catch: (error) =>
+          new CacheError({
+            message: `获取缓存版本号失败: ${namespace}`,
+            cause: error,
+          }),
+      });
+      let next = 1;
+      if (current) {
+        const parsed = Number.parseInt(current);
+        if (!Number.isNaN(parsed)) {
+          next = parsed + 1;
+        }
+      }
+      yield* Effect.tryPromise({
+        try: () => kv.put(key, next.toString()),
+        catch: (error) =>
+          new CacheError({
+            message: `更新缓存版本号失败: ${namespace}`,
+            cause: error,
+          }),
+      });
+    }).pipe(Effect.catchAll((error) => Effect.logError(error.message)));
+
+  return {
+    cachedData,
+    deleteCachedData,
+    getCacheVersion,
+    bumpCacheVersion,
+  } as const;
+});
+
+/**
+ * Effect 版本的 CacheService
+ *
+ * 使用方式:
+ * ```typescript
+ * const program = Effect.gen(function* () {
+ *   const { cachedData } = yield* CacheService;
+ *   const data = yield* cachedData(
+ *     ["posts", "list"],
+ *     MySchema,
+ *     fetchFromDbEffect
+ *   );
+ *   return data;
+ * });
+ *
+ * const result = await runtime.runPromise(program.pipe(
+ *   Effect.provide(CacheService.Live)
+ * ));
+ * ```
+ */
+export class CacheService extends Context.Tag(
+  "./features/cache/cache.service.effect/CacheService",
+)<CacheService, Effect.Effect.Success<typeof make>>() {
+  static readonly Live = Layer.effect(this, make);
+}

--- a/src/features/posts/posts.service.effect.ts
+++ b/src/features/posts/posts.service.effect.ts
@@ -1,0 +1,146 @@
+/**
+ * Effect 版本的 PostsService 示例
+ *
+ * 这个文件展示了如何使用 Effect 的 Context/Tag 模式来实现文章服务。
+ * 与 async/await 版本 (posts.service.ts) 并存，作为 Effect 用法的示例。
+ *
+ * 主要特点:
+ * - 使用 Effect.gen 替代 async/await
+ * - 使用 Effect.tryPromise 包装现有的 async/await 函数
+ * - 与 Effect 版本的 CacheService 集成
+ */
+
+import { Context, Data, Effect, Layer, Schema } from "effect";
+import { DatabaseService } from "@/services/db";
+import { CacheService } from "@/features/cache/cache.service.effect";
+import { generateTableOfContents } from "@/features/posts/utils/toc";
+import * as PostRepo from "@/features/posts/data/posts.data";
+
+// Effect 错误类型
+export class PostNotFoundError extends Data.TaggedError("PostNotFoundError")<{
+  slug: string;
+}> {}
+
+export class PostRepositoryError extends Data.TaggedError(
+  "PostRepositoryError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+// 将 Zod Schema 转换为 Effect Schema
+// 注意：这里使用 Schema.Unknown 作为简化示例
+// 在实际应用中，可以使用 Schema.transform 或手动定义 Effect Schema
+const PostListResponseSchema = Schema.Unknown;
+const PostWithTocSchema = Schema.Unknown;
+
+// Effect 版本的 PostsService
+const make = Effect.gen(function* () {
+  const { cachedData, getCacheVersion } = yield* CacheService;
+  const { db } = yield* DatabaseService;
+
+  /**
+   * 获取分页文章列表 (带缓存)
+   */
+  const getPostsCursor = (
+    options: {
+      cursor?: number;
+      limit?: number;
+      tagName?: string;
+    } = {},
+  ) =>
+    Effect.gen(function* () {
+      const version = yield* getCacheVersion("posts:list");
+      const cacheKey = [
+        "posts",
+        "list",
+        version,
+        options.tagName ?? "all",
+        options.limit ?? 10,
+        options.cursor ?? 0,
+      ];
+
+      // 使用 Effect.tryPromise 包装现有的 async 函数
+      const fetcher = Effect.tryPromise({
+        try: () =>
+          PostRepo.getPostsCursor(db, {
+            ...options,
+            publicOnly: true,
+          }),
+        catch: (error) =>
+          new PostRepositoryError({
+            message: "获取文章列表失败",
+            cause: error,
+          }),
+      });
+
+      return yield* cachedData(cacheKey, PostListResponseSchema, fetcher, {
+        ttl: 60 * 60 * 24 * 7, // 7 days
+      });
+    });
+
+  /**
+   * 通过 slug 查找文章 (带缓存)
+   */
+  const findPostBySlug = (slug: string) =>
+    Effect.gen(function* () {
+      const effect = Effect.gen(function* () {
+        const post = yield* Effect.tryPromise({
+          try: () => PostRepo.findPostBySlug(db, slug, { publicOnly: true }),
+          catch: (error) =>
+            new PostRepositoryError({
+              message: `获取文章失败: ${slug}`,
+              cause: error,
+            }),
+        });
+        if (!post) return null;
+        return {
+          ...post,
+          toc: generateTableOfContents(post.contentJson),
+        };
+      });
+
+      const cacheKey = ["post", slug];
+      const post = yield* cachedData(cacheKey, PostWithTocSchema, effect, {
+        ttl: 60 * 60 * 24 * 7, // 7 days
+      });
+
+      if (!post) {
+        return yield* new PostNotFoundError({ slug });
+      }
+      return post;
+    });
+
+  return {
+    getPostsCursor,
+    findPostBySlug,
+  } as const;
+});
+
+/**
+ * Effect 版本的 PostsService
+ *
+ * 使用方式:
+ * ```typescript
+ * const program = Effect.gen(function* () {
+ *   const { findPostBySlug } = yield* PostsService;
+ *   const post = yield* findPostBySlug("my-post-slug");
+ *   return post;
+ * });
+ *
+ * const result = await runtime.runPromise(program.pipe(
+ *   Effect.provide(PostsService.Live),
+ *   Effect.provide(CacheService.Live),
+ *   // ... 其他依赖
+ * ));
+ * ```
+ *
+ * 注意：PostsService 依赖 CacheService 和 DatabaseService
+ */
+export class PostsService extends Context.Tag(
+  "./features/posts/posts.service.effect/PostsService",
+)<PostsService, Effect.Effect.Success<typeof make>>() {
+  static readonly Live = Layer.effect(this, make).pipe(
+    Layer.provide(CacheService.Live),
+  );
+}

--- a/src/lib/effect/errors.ts
+++ b/src/lib/effect/errors.ts
@@ -1,0 +1,16 @@
+import { Data } from "effect";
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export class StorageError extends Data.TaggedError("StorageError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export class ValidationError extends Data.TaggedError("ValidationError")<{
+  readonly message: string;
+  readonly field?: string;
+}> {}

--- a/src/lib/effect/result.ts
+++ b/src/lib/effect/result.ts
@@ -1,0 +1,60 @@
+import { Effect } from "effect";
+import type { AppRuntime } from "@/services";
+
+/**
+ * 可序列化的错误类型
+ *
+ * 只保留 _tag 和 message，用于前端穷尽匹配和错误展示
+ */
+export type SerializableError<TError> = TError extends {
+  readonly _tag: infer Tag;
+}
+  ? { readonly _tag: Tag; readonly message: string }
+  : { readonly message: string };
+
+function toSerializableError<TError>(error: TError): SerializableError<TError> {
+  if (error !== null && typeof error === "object" && "_tag" in error) {
+    return {
+      _tag: (error as { _tag: unknown })._tag,
+      message:
+        "message" in error
+          ? String((error as { message: unknown }).message)
+          : "Unknown error",
+    } as SerializableError<TError>;
+  }
+  return {
+    message: error instanceof Error ? error.message : String(error),
+  } as SerializableError<TError>;
+}
+
+export type ApiResult<TData, TError> =
+  | { ok: true; data: TData }
+  | { ok: false; error: SerializableError<TError> };
+
+export function toApiResult<TValue, TError, TRequirements>(
+  effect: Effect.Effect<TValue, TError, TRequirements>,
+): Effect.Effect<ApiResult<TValue, TError>, never, TRequirements> {
+  return Effect.match(effect, {
+    onSuccess: (data) => ({ ok: true as const, data }),
+    onFailure: (error) => ({
+      ok: false as const,
+      error: toSerializableError(error),
+    }),
+  });
+}
+
+export function runApiEffectWithRuntime<TValue, TError>(
+  runtime: AppRuntime,
+  effect: Effect.Effect<TValue, TError, never>,
+): Promise<ApiResult<TValue, TError>> {
+  return runtime.runPromise(toApiResult(effect));
+}
+
+export type RunApiEffectWithRuntime = <TValue, TError>(
+  effect: Effect.Effect<TValue, TError, never>,
+) => Promise<ApiResult<TValue, TError>>;
+
+export const createRunEffect =
+  (runtime: AppRuntime): RunApiEffectWithRuntime =>
+  (effect) =>
+    runApiEffectWithRuntime(runtime, effect);

--- a/src/lib/hono/routes.ts
+++ b/src/lib/hono/routes.ts
@@ -16,6 +16,7 @@ import postsDetailRoute from "@/features/posts/api/hono/posts.detail.route";
 import postsRelatedRoute from "@/features/posts/api/hono/posts.related.route";
 import tagsRoute from "@/features/tags/api/hono/tags.list.route";
 import searchRoute from "@/features/search/api/hono/search.route";
+import { createAppRuntime, createRunEffect } from "@/services";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -137,10 +138,15 @@ app.post(
 app.all("*", shieldMiddleware);
 
 app.all("*", (c) => {
+  // 为每个请求创建 Effect Runtime
+  const runtime = createAppRuntime(c.env, c.executionCtx);
+
   return handler.fetch(c.req.raw, {
     context: {
       env: c.env,
       executionCtx: c.executionCtx,
+      runtime,
+      runEffect: createRunEffect(runtime),
     },
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import type { AppRuntime, RunApiEffectWithRuntime } from "@/services";
 import { handleEmailMessage } from "@/features/email/email.queue";
 import { app } from "@/lib/hono";
 import { queueMessageSchema } from "@/lib/queue/queue.schema";
@@ -14,6 +15,8 @@ declare module "@tanstack/react-start" {
       requestContext: {
         env: Env;
         executionCtx: ExecutionContext;
+        runtime: AppRuntime;
+        runEffect: RunApiEffectWithRuntime;
       };
     };
   }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,19 @@
+import { Context, Effect, Layer } from "effect";
+import { CloudflareEnvService } from "./cloudflare-env";
+import { DatabaseService } from "./db";
+import type { Auth } from "@/lib/auth/auth.server";
+import { getAuth } from "@/lib/auth/auth.server";
+
+export class AuthService extends Context.Tag("./services/auth/AuthService")<
+  AuthService,
+  { auth: Auth }
+>() {
+  static readonly Live = Layer.effect(
+    this,
+    Effect.gen(function* () {
+      const { db } = yield* DatabaseService;
+      const { env } = yield* CloudflareEnvService;
+      return { auth: getAuth({ db, env }) };
+    }),
+  ).pipe(Layer.provide(DatabaseService.Live));
+}

--- a/src/services/cloudflare-env.ts
+++ b/src/services/cloudflare-env.ts
@@ -1,0 +1,14 @@
+import { Context, Layer } from "effect";
+
+export class CloudflareEnvService extends Context.Tag(
+  "./services/cloudflare-env/CloudflareEnv",
+)<CloudflareEnvService, { env: Env }>() {
+  static Live = (env: Env) => Layer.succeed(this, { env });
+}
+
+export class CloudflareExecutionContextService extends Context.Tag(
+  "./services/cloudflare-env/CloudflareExecutionContextService",
+)<CloudflareExecutionContextService, { executionCtx: ExecutionContext }>() {
+  static Live = (executionCtx: ExecutionContext) =>
+    Layer.succeed(this, { executionCtx });
+}

--- a/src/services/d1.ts
+++ b/src/services/d1.ts
@@ -1,0 +1,15 @@
+import { Context, Effect, Layer } from "effect";
+import { CloudflareEnvService } from "./cloudflare-env";
+
+export class D1Service extends Context.Tag("./services/d1/D1Service")<
+  D1Service,
+  { d1: D1Database }
+>() {
+  static readonly Live = Layer.effect(
+    this,
+    Effect.gen(function* () {
+      const { env } = yield* CloudflareEnvService;
+      return { d1: env.DB };
+    }),
+  );
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,0 +1,16 @@
+import { Context, Effect, Layer } from "effect";
+import { CloudflareEnvService } from "./cloudflare-env";
+import type { DB } from "@/lib/db";
+import { getDb } from "@/lib/db";
+
+export class DatabaseService extends Context.Tag(
+  "./services/db/DatabaseService",
+)<DatabaseService, { db: DB }>() {
+  static readonly Live = Layer.effect(
+    this,
+    Effect.gen(function* () {
+      const { env } = yield* CloudflareEnvService;
+      return { db: getDb(env) };
+    }),
+  );
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,65 @@
+import { Layer, ManagedRuntime } from "effect";
+import {
+  CloudflareEnvService,
+  CloudflareExecutionContextService,
+} from "./cloudflare-env";
+import { D1Service } from "./d1";
+import { DatabaseService } from "./db";
+import { KVService } from "./kv";
+import { R2Service } from "./r2";
+import type { AuthService } from "./auth";
+
+// Re-export services
+export { AuthService } from "./auth";
+export {
+  CloudflareEnvService,
+  CloudflareExecutionContextService,
+} from "./cloudflare-env";
+export { D1Service } from "./d1";
+export { DatabaseService } from "./db";
+export { KVService } from "./kv";
+export { R2Service } from "./r2";
+
+// Re-export Effect runtime types and functions
+export type {
+  RunApiEffectWithRuntime,
+  ApiResult,
+  SerializableError,
+} from "@/lib/effect/result";
+export {
+  createRunEffect,
+  runApiEffectWithRuntime,
+  toApiResult,
+} from "@/lib/effect/result";
+
+export function createAppRuntime(env: Env, executionCtx: ExecutionContext) {
+  // 逐层构建，使用 Layer.provideMerge 确保依赖传递
+  const L1 = Layer.mergeAll(
+    CloudflareEnvService.Live(env),
+    CloudflareExecutionContextService.Live(executionCtx),
+  );
+
+  const L2 = Layer.mergeAll(
+    D1Service.Live,
+    KVService.Live,
+    R2Service.Live,
+  ).pipe(Layer.provideMerge(L1));
+
+  const L3 = DatabaseService.Live.pipe(Layer.provideMerge(L2));
+
+  return ManagedRuntime.make(L3);
+}
+
+export type AppRuntime = ReturnType<typeof createAppRuntime>;
+
+// 所有可用的服务类型
+export type AppServices =
+  // 基础服务
+  | CloudflareEnvService
+  | CloudflareExecutionContextService
+  | D1Service
+  | KVService
+  | R2Service
+  | DatabaseService
+  // 业务服务 (Effect 版本作为示例，可选集成)
+  | AuthService;

--- a/src/services/kv.ts
+++ b/src/services/kv.ts
@@ -1,0 +1,15 @@
+import { Context, Effect, Layer } from "effect";
+import { CloudflareEnvService } from "./cloudflare-env";
+
+export class KVService extends Context.Tag("./services/kv/KVService")<
+  KVService,
+  { kv: KVNamespace }
+>() {
+  static readonly Live = Layer.effect(
+    this,
+    Effect.gen(function* () {
+      const { env } = yield* CloudflareEnvService;
+      return { kv: env.KV };
+    }),
+  );
+}

--- a/src/services/r2.ts
+++ b/src/services/r2.ts
@@ -1,0 +1,15 @@
+import { Context, Effect, Layer } from "effect";
+import { CloudflareEnvService } from "./cloudflare-env";
+
+export class R2Service extends Context.Tag("./services/r2/R2Service")<
+  R2Service,
+  { r2: R2Bucket }
+>() {
+  static readonly Live = Layer.effect(
+    this,
+    Effect.gen(function* () {
+      const { env } = yield* CloudflareEnvService;
+      return { r2: env.R2 };
+    }),
+  );
+}


### PR DESCRIPTION
- 添加 effect 依赖到 package.json
- 创建 src/lib/effect/ 目录，包含 Result 类型和错误定义
- 创建 src/services/ 目录，实现 Effect 版本的服务层 (CloudflareEnv, D1, KV, R2, DB, Auth)
- 添加 Effect 版本的 cache.service.effect.ts 和 posts.service.effect.ts 作为示例
- 更新 server.ts，在 requestContext 中添加 runtime 和 runEffect
- 更新 lib/hono/routes.ts，为每个请求创建 Effect Runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能
* 引入数据缓存机制，优化应用性能和响应速度

## 改进
* 增强错误处理与恢复机制
* 升级后端架构以支持更灵活的服务扩展

<!-- end of auto-generated comment: release notes by coderabbit.ai -->